### PR TITLE
修复autoselect开启时导致的检验提示定位不正确问题

### DIFF
--- a/packages/edit/src/mixin.js
+++ b/packages/edit/src/mixin.js
@@ -302,7 +302,8 @@ export default {
           inputElem = cell.querySelector(compRender.autofocus)
         }
         if (inputElem) {
-          inputElem[autoselect ? 'select' : 'focus']()
+          inputElem.focus()
+          if (autoselect)inputElem.select()
           if (browse.msie) {
             let textRange = inputElem.createTextRange()
             textRange.collapse(false)


### PR DESCRIPTION
上次的误操作抱歉，clone网速实在太慢了，就页面端操作了，我想应该是浏览器插件自动翻译页面导致把文件名改成了中文，没注意到导致的，实在抱歉