### PR TITLE
Fix:substitution division in scss styles

### DIFF
--- a/styles/button.scss
+++ b/styles/button.scss
@@ -124,7 +124,7 @@ $btnThemeList: (
     line-height: 1;
     border: 1px solid $vxe-input-border-color;
     &.is--round {
-      border-radius: $vxe-button-height-default / 2;
+      border-radius: $vxe-button-height-default * 0.5;
     }
     &:not(.is--round) {
       border-radius: $vxe-border-radius;
@@ -223,7 +223,7 @@ $btnThemeList: (
         min-width: $vxe-button-height-medium;
       }
       &.is--round {
-        border-radius: $vxe-button-height-medium / 2;
+        border-radius: $vxe-button-height-medium * 0.5;
       }
     }
     .vxe-button--loading-icon,
@@ -239,7 +239,7 @@ $btnThemeList: (
         min-width: $vxe-button-height-small;
       }
       &.is--round {
-        border-radius: $vxe-button-height-small / 2;
+        border-radius: $vxe-button-height-small * 0.5;
       }
     }
     .vxe-button--loading-icon,
@@ -255,7 +255,7 @@ $btnThemeList: (
         min-width: $vxe-button-height-mini;
       }
       &.is--round {
-        border-radius: $vxe-button-height-mini / 2;
+        border-radius: $vxe-button-height-mini * 0.5;
       }
     }
     .vxe-button--loading-icon,

--- a/styles/modal.scss
+++ b/styles/modal.scss
@@ -314,10 +314,10 @@
       cursor: w-resize;
     }
     .wl-resize {
-      left: -#{$SpaceSize / 2 + 1}px;
+      left: -#{$SpaceSize * 0.5 + 1}px;
     }
     .wr-resize {
-      right: -#{$SpaceSize / 2 + 1}px;
+      right: -#{$SpaceSize * 0.5 + 1}px;
     }
     .swst-resize,
     .sest-resize,
@@ -359,10 +359,10 @@
       cursor: s-resize;
     }
     .st-resize {
-      top: -#{$SpaceSize / 2 + 1}px;
+      top: -#{$SpaceSize * 0.5 + 1}px;
     }
     .sb-resize {
-      bottom: -#{$SpaceSize / 2 + 1}px;
+      bottom: -#{$SpaceSize * 0.5 + 1}px;
     }
   }
 }

--- a/styles/table.scss
+++ b/styles/table.scss
@@ -474,7 +474,7 @@
     line-height: $vxe-table-row-line-height;
     text-align: left;
     &:not(.col--ellipsis) {
-      padding: #{floor(($vxe-table-row-height-default - $vxe-table-row-line-height) / 2)} 0;
+      padding: #{floor(($vxe-table-row-height-default - $vxe-table-row-line-height) * 0.5)} 0;
     }
     &.col--current {
       background-color: $vxe-table-column-current-background-color;
@@ -609,7 +609,7 @@
     .vxe-body--column,
     .vxe-footer--column {
       &:not(.col--ellipsis) {
-        padding: #{floor(($vxe-table-row-height-medium - $vxe-table-row-line-height) / 2)} 0;
+        padding: #{floor(($vxe-table-row-height-medium - $vxe-table-row-line-height) * 0.5)} 0;
       }
     }
     .vxe-cell {
@@ -635,7 +635,7 @@
     .vxe-body--column,
     .vxe-footer--column {
       &:not(.col--ellipsis) {
-        padding: #{floor(($vxe-table-row-height-small - $vxe-table-row-line-height) / 2)} 0;
+        padding: #{floor(($vxe-table-row-height-small - $vxe-table-row-line-height) * 0.5)} 0;
       }
     }
     .vxe-cell {
@@ -661,7 +661,7 @@
     .vxe-body--column,
     .vxe-footer--column {
       &:not(.col--ellipsis) {
-        padding: #{floor(($vxe-table-row-height-mini - $vxe-table-row-line-height) / 2)} 0;
+        padding: #{floor(($vxe-table-row-height-mini - $vxe-table-row-line-height) * 0.5)} 0;
       }
     }
     .vxe-cell {


### PR DESCRIPTION
由于`node-sass`后面基本上不再维护，所以现在大部分项目都已经迁移到`dart-sass`，在使用按需引入模块样式时，会提示编译错误。

建议`vxe`后面也做迁移，这里使用简单的办法做了两种`sass`编译的兼容。
