### PR TITLE
表格新增的临时行不使用 stipe 属性的样式

### DIFF
--- a/packages/table/src/body.ts
+++ b/packages/table/src/body.ts
@@ -525,7 +525,7 @@ export default defineComponent({
           'vxe-body--row',
           isDeepRow ? `row--level-${rowLevel}` : '',
           {
-            'row--stripe': stripe && (_rowIndex + 1) % 2 === 0,
+            'row--stripe': stripe && (_rowIndex + 1) % 2 === 0 && !isNewRow,
             'is--new': isNewRow,
             'is--expand-row': isExpandRow,
             'is--expand-tree': isExpandTree,


### PR DESCRIPTION
文档中描述 stripe 属性: 不会在新增的行上生效.
![image](https://github.com/user-attachments/assets/cb6164dc-d943-4584-8455-62865ab6d3f1)
