### PR TITLE
fix(table): respect cellRender outside edit mode

### DIFF
--- a/packages/table/src/cell.ts
+++ b/packages/table/src/cell.ts
@@ -463,15 +463,15 @@ export const Cell = {
       if (defaultSlot) {
         return renderCellBaseVNs(h, params, $table.callSlot(defaultSlot, params, h))
       }
-      const renderOpts = editRenderOpts || cellRenderOpts
+      const renderOpts = cellRenderOpts || editRenderOpts
       // 如果是编辑表格：renderTableCell > formatter
       // 如果是查看表格：renderTableDefault > formatter
       if (renderOpts) {
         const compConf = renderer.get(renderOpts.name)
         if (compConf) {
-          const renderFn = editRenderOpts ? (compConf.renderTableCell || compConf.renderCell) : (compConf.renderTableDefault || compConf.renderDefault)
+          const renderFn = cellRenderOpts ? (compConf.renderTableDefault || compConf.renderDefault) : (compConf.renderTableCell || compConf.renderCell)
           if (renderFn) {
-            return renderCellBaseVNs(h, params, getSlotVNs(renderFn.call($table, h, renderOpts, Object.assign({ $type: editRenderOpts ? 'edit' : 'cell' }, params))))
+            return renderCellBaseVNs(h, params, getSlotVNs(renderFn.call($table, h, renderOpts, Object.assign({ $type: cellRenderOpts ? 'cell' : 'edit' }, params))))
           }
         }
       }


### PR DESCRIPTION
## What changed

- Prefer `cellRender` when rendering a cell outside edit mode.
- Keep `editRender` as the fallback when no `cellRender` is configured.
- Pass the matching renderer type (`cell` or `edit`) to the selected renderer.

## Why

When a column defines both `cellRender` and `editRender`, the non-edit path previously selected `editRender` first. As a result, `cellRender` was never used, even when the cell was not being edited.

This keeps the existing behavior for columns that only define `editRender`, while allowing columns with both renderers to use `cellRender` for display and `editRender` during editing.

Fixes #3258

## Validation

- `eslint packages/table/src/cell.ts` passed.
- `npm run lib` passed (library bundle and module builds).
- Full repository lint/build still reports pre-existing lint errors in `gulpfile.js` and example Vue files; none are in the changed file.